### PR TITLE
Updates the harebrain library to S4TF v0.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "Harebrain", targets: ["Harebrain"]),
     ],
   dependencies: [
-    .package(url: "https://github.com/saeta/Just", .branch("master")),
+    .package(url: "https://github.com/saeta/Just", from: "0.7.2"),
     .package(url: "https://github.com/mxcl/Path.swift", .branch("master")),
   ],
   targets: [

--- a/Sources/Harebrain/00_load_data.swift
+++ b/Sources/Harebrain/00_load_data.swift
@@ -4,6 +4,8 @@ file to edit: 00_load_data.ipynb
 
 */
 
+
+
 precedencegroup ExponentiationPrecedence {
     associativity: right
     higherThan: MultiplicationPrecedence

--- a/Sources/Harebrain/01_matmul.swift
+++ b/Sources/Harebrain/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/Sources/Harebrain/01a_fastai_layers.swift
+++ b/Sources/Harebrain/01a_fastai_layers.swift
@@ -4,18 +4,20 @@ file to edit: 01a_fastai_layers.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
 public extension Tensor where Scalar: TensorFlowFloatingPoint {
     init(kaimingNormal shape: TensorShape, negativeSlope: Double = 1.0) {
         // Assumes Leaky ReLU nonlinearity
-        let gain = Scalar(sqrt(2.0 / (1.0 + pow(negativeSlope, 2))))
+        let gain = Scalar.init(TensorFlow.sqrt(2.0 / (1.0 + TensorFlow.pow(negativeSlope, 2))))
         let spatialDimCount = shape.count - 2
         let receptiveField = shape[0..<spatialDimCount].contiguousSize
         let fanIn = shape[spatialDimCount] * receptiveField
         self.init(randomNormal: shape)
-        self *= Tensor<Scalar>(gain/sqrt(Scalar(fanIn)))
+        self *= Tensor<Scalar>(gain/TensorFlow.sqrt(Scalar(fanIn)))
     }
 }
 
@@ -44,7 +46,7 @@ public protocol FALayer: Layer {
 
 public extension FALayer {
     @differentiable(vjp: callGrad)
-    func call(_ input: Input) -> Output {
+    func callAsFunction(_ input: Input) -> Output {
         let activation = forward(input)
         for d in delegates { d(activation) }
         return activation
@@ -55,7 +57,7 @@ public extension FALayer {
     // NOTE: If we use `@differentiating`, then there is a linker error. So we use `@differentiable` instead.
     //    TF-476: https://bugs.swift.org/browse/TF-476
     func callGrad(_ input: Input) ->
-        (Output, (Self.Output.CotangentVector) -> (Self.CotangentVector, Self.Input.CotangentVector)) {
+        (Output, (Self.Output.TangentVector) -> (Self.TangentVector, Self.Input.TangentVector)) {
         return Swift.valueWithPullback(at: self, input) { (m, i) in m.forward(i) }
     }
     
@@ -71,8 +73,10 @@ public extension FALayer {
 
 
 
-@_fixed_layout
+@frozen
 public struct FADense<Scalar: TensorFlowFloatingPoint>: FALayer { 
+    public typealias Input = Tensor<Scalar>
+    public typealias Output = Tensor<Scalar>
     public var weight: Tensor<Scalar>
     public var bias: Tensor<Scalar>
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -96,14 +100,14 @@ public struct FADense<Scalar: TensorFlowFloatingPoint>: FALayer {
 
 public extension FADense {
     init(_ nIn: Int, _ nOut: Int, activation: @escaping Activation = identity) {
-        self.init(weight: Tensor(kaimingNormal: [nIn, nOut]),
+        self.init(weight: Tensor(kaimingNormal: [nIn, nOut], negativeSlope: 1.0),
                   bias: Tensor(zeros: [nOut]),
                   activation: activation)
     }
 }
 
 
-@_fixed_layout
+@frozen
 public struct FANoBiasConv2D<Scalar: TensorFlowFloatingPoint>: FALayer {
     public var filter: Tensor<Scalar>
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
@@ -125,9 +129,9 @@ public struct FANoBiasConv2D<Scalar: TensorFlowFloatingPoint>: FALayer {
 
     @differentiable
     public func forward(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return activation(input.convolved2D(withFilter: filter,
-                                            strides: (1, strides.0, strides.1, 1),
-                                            padding: padding))
+        return activation(conv2D(input, filter: filter,
+                                        strides: (1, strides.0, strides.1, 1),
+                                        padding: padding))
     }
 }
 
@@ -142,7 +146,7 @@ public extension FANoBiasConv2D {
             filterShape.0, filterShape.1,
             filterShape.2, filterShape.3])
         self.init(
-            filter: Tensor(kaimingNormal: filterTensorShape),
+            filter: Tensor(kaimingNormal: filterTensorShape, negativeSlope: 1.0),
             activation: activation,
             strides: strides,
             padding: padding)
@@ -160,7 +164,7 @@ public extension FANoBiasConv2D {
 }
 
 
-@_fixed_layout
+@frozen
 public struct FAConv2D<Scalar: TensorFlowFloatingPoint>: FALayer {
     public typealias Input = Tensor<Scalar>
     public typealias Output = Tensor<Scalar>
@@ -188,9 +192,9 @@ public struct FAConv2D<Scalar: TensorFlowFloatingPoint>: FALayer {
 
     @differentiable
     public func forward(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return activation(input.convolved2D(withFilter: filter,
-                                            strides: (1, strides.0, strides.1, 1),
-                                            padding: padding) + bias)
+        return activation(conv2D(input, filter: filter,
+                                        strides: (1, strides.0, strides.1, 1),
+                                        padding: padding) + bias)
     }
 }
 
@@ -205,7 +209,7 @@ public extension FAConv2D {
             filterShape.0, filterShape.1,
             filterShape.2, filterShape.3])
         self.init(
-            filter: Tensor(kaimingNormal: filterTensorShape),
+            filter: Tensor(kaimingNormal: filterTensorShape, negativeSlope: 1.0),
             bias: Tensor(zeros: TensorShape([filterShape.3])),
             activation: activation,
             strides: strides,
@@ -224,7 +228,7 @@ public extension FAConv2D {
 }
 
 
-@_fixed_layout
+@frozen
 public struct FAAvgPool2D<Scalar: TensorFlowFloatingPoint>: FALayer {
     @noDerivative let poolSize: (Int, Int, Int, Int)
     @noDerivative let strides: (Int, Int, Int, Int)
@@ -254,12 +258,12 @@ public struct FAAvgPool2D<Scalar: TensorFlowFloatingPoint>: FALayer {
 
     @differentiable
     public func forward(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return input.averagePooled(kernelSize: poolSize, strides: strides, padding: padding)
+        return avgPool2D(input, filterSize: poolSize, strides: strides, padding: padding)
     }
 }
 
 
-@_fixed_layout
+@frozen
 public struct FAGlobalAvgPool2D<Scalar: TensorFlowFloatingPoint>: FALayer {
     public init() {}
 
@@ -274,7 +278,7 @@ extension Array: Layer where Element: Layer, Element.Input == Element.Output {
     public typealias Output = Element.Output
     
     @differentiable(vjp: _vjpApplied)
-    public func call(_ input: Input) -> Output {
+    public func callAsFunction(_ input: Input) -> Output {
         var activation = input
         for layer in self {
             activation = layer(activation)
@@ -283,24 +287,24 @@ extension Array: Layer where Element: Layer, Element.Input == Element.Output {
     }
     
     public func _vjpApplied(_ input: Input)
-        -> (Output, (Output.CotangentVector) -> (Array.CotangentVector, Input.CotangentVector))
+        -> (Output, (Output.TangentVector) -> (Array.TangentVector, Input.TangentVector))
     {
         var activation = input
-        var pullbacks: [(Input.CotangentVector) -> (Element.CotangentVector, Input.CotangentVector)] = []
+        var pullbacks: [(Input.TangentVector) -> (Element.TangentVector, Input.TangentVector)] = []
         for layer in self {
             let (newActivation, newPullback) = layer.valueWithPullback(at: activation) { $0($1) }
             activation = newActivation
             pullbacks.append(newPullback)
         }
-        func pullback(_ v: Input.CotangentVector) -> (Array.CotangentVector, Input.CotangentVector) {
+        func pullback(_ v: Input.TangentVector) -> (Array.TangentVector, Input.TangentVector) {
             var activationGradient = v
-            var layerGradients: [Element.CotangentVector] = []
+            var layerGradients: [Element.TangentVector] = []
             for pullback in pullbacks.reversed() {
                 let (newLayerGradient, newActivationGradient) = pullback(activationGradient)
                 activationGradient = newActivationGradient
                 layerGradients.append(newLayerGradient)
             }
-            return (Array.CotangentVector(layerGradients.reversed()), activationGradient)
+            return (Array.TangentVector(layerGradients.reversed()), activationGradient)
         }
         return (activation, pullback)
     }
@@ -332,13 +336,13 @@ public func **<T : BinaryFloatingPoint>(_ x: T, _ y: T) -> T {
 }
 
 public func **<T>(_ x: Tensor<T>, _ y: Tensor<T>) -> Tensor<T>
-  where T : FloatingPoint { return pow(x, y)}
+  where T : TensorFlowFloatingPoint { return pow(x, y)}
 
 public func **<T>(_ x: T, _ y: Tensor<T>) -> Tensor<T>
-  where T : FloatingPoint { return pow(x, y)}
+  where T : TensorFlowFloatingPoint { return pow(x, y)}
 
 public func **<T>(_ x: Tensor<T>, _ y: T) -> Tensor<T>
-  where T : FloatingPoint { return pow(x, y)}
+  where T : TensorFlowFloatingPoint { return pow(x, y)}
 
 public extension Differentiable {
     @differentiable

--- a/Sources/Harebrain/01a_fastai_layers.swift
+++ b/Sources/Harebrain/01a_fastai_layers.swift
@@ -109,6 +109,10 @@ public extension FADense {
 
 @frozen
 public struct FANoBiasConv2D<Scalar: TensorFlowFloatingPoint>: FALayer {
+    // TF-603 workaround.
+    public typealias Input = Tensor<Scalar>
+    public typealias Output = Tensor<Scalar>
+
     public var filter: Tensor<Scalar>
     public typealias Activation = @differentiable (Tensor<Scalar>) -> Tensor<Scalar>
     @noDerivative public let activation: Activation
@@ -230,6 +234,10 @@ public extension FAConv2D {
 
 @frozen
 public struct FAAvgPool2D<Scalar: TensorFlowFloatingPoint>: FALayer {
+    // TF-603
+    public typealias Input = Tensor<Scalar>
+    public typealias Output = Tensor<Scalar>
+
     @noDerivative let poolSize: (Int, Int, Int, Int)
     @noDerivative let strides: (Int, Int, Int, Int)
     @noDerivative let padding: Padding

--- a/Sources/Harebrain/02_fully_connected.swift
+++ b/Sources/Harebrain/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/Sources/Harebrain/02a_why_sqrt5.swift
+++ b/Sources/Harebrain/02a_why_sqrt5.swift
@@ -4,6 +4,8 @@ file to edit: 02a_why_sqrt5.ipynb
 
 */
 
+
+
 import Foundation
 import TensorFlow
 import Path
@@ -18,11 +20,11 @@ func leakyRelu<T: TensorFlowFloatingPoint>(
 extension Tensor where Scalar: TensorFlowFloatingPoint {
     init(kaimingUniform shape: TensorShape, negativeSlope: Double = 1.0) {
         // Assumes Leaky ReLU nonlinearity
-        let gain = Scalar(sqrt(2.0 / (1.0 + pow(negativeSlope, 2))))
+        let gain = Scalar.init(TensorFlow.sqrt(2.0 / (1.0 + TensorFlow.pow(negativeSlope, 2))))
         let spatialDimCount = shape.count - 2
         let receptiveField = shape[0..<spatialDimCount].contiguousSize
         let fanIn = shape[shape.count - 2] * receptiveField
-        let bound = sqrt(Scalar(3.0)) * gain / sqrt(Scalar(fanIn))
+        let bound = TensorFlow.sqrt(Scalar(3.0)) * gain / TensorFlow.sqrt(Scalar(fanIn))
         self = bound * (2 * Tensor(randomUniform: shape, generator: &PhiloxRandomNumberGenerator.global) - 1)
     }
 }

--- a/Sources/Harebrain/03_minibatch_training.swift
+++ b/Sources/Harebrain/03_minibatch_training.swift
@@ -4,6 +4,8 @@ file to edit: 03_minibatch_training.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
@@ -28,7 +30,7 @@ public func batchedRanges(start:Int, end:Int, bs:Int) -> UnfoldSequence<Range<In
 
 public struct DataBatch<Inputs: Differentiable & TensorGroup, Labels: TensorGroup>: TensorGroup {
     public var xb: Inputs
-    public var yb: Labels    
+    public var yb: Labels
     
     public init(xb: Inputs, yb: Labels){ (self.xb,self.yb) = (xb,yb) }
 }

--- a/Sources/Harebrain/04_callbacks.swift
+++ b/Sources/Harebrain/04_callbacks.swift
@@ -4,6 +4,8 @@ file to edit: 04_callbacks.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
@@ -16,7 +18,7 @@ public struct BasicModel: Layer {
     }
     
     @differentiable
-    public func call(_ input: Tensor<Float>) -> Tensor<Float> {
+    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         return layer2(layer1(input))
     }
 }
@@ -110,7 +112,7 @@ public final class Learner<Label: TensorGroup,
     
     public private(set) var epochCount = 0
     public private(set) var currentEpoch = 0
-    public private(set) var currentGradient = Model.CotangentVector.zero
+    public private(set) var currentGradient = Model.TangentVector.zero
     public private(set) var currentLoss = Loss.zero
     public private(set) var inTrain = false
     public private(set) var pctEpochs = Float.zero

--- a/Sources/Harebrain/05_anneal.swift
+++ b/Sources/Harebrain/05_anneal.swift
@@ -4,6 +4,8 @@ file to edit: 05_anneal.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/Sources/Harebrain/05b_early_stopping.swift
+++ b/Sources/Harebrain/05b_early_stopping.swift
@@ -4,6 +4,8 @@ file to edit: 05b_early_stopping.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 import Python

--- a/Sources/Harebrain/06_cuda.swift
+++ b/Sources/Harebrain/06_cuda.swift
@@ -4,6 +4,8 @@ file to edit: 06_cuda.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 import Python
@@ -30,9 +32,12 @@ public struct CnnModel: Layer {
         }
         linear = FADense<Float>(filters.last!, nOut)
     }
+    // Workaround for TF-603
+    public typealias Input = TF
+    public typealias Output = TF
     
     @differentiable
-    public func call(_ input: TF) -> TF {
-        return input.sequenced(through: convs, pool, linear)
+    public func callAsFunction(_ input: TF) -> TF {
+        return linear.forward(pool.forward(convs(input)))
     }
 }

--- a/Sources/Harebrain/07_batchnorm.swift
+++ b/Sources/Harebrain/07_batchnorm.swift
@@ -4,6 +4,8 @@ file to edit: 07_batchnorm.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 import Python
@@ -36,8 +38,8 @@ extension LearningPhaseDependent {
 
     @differentiating(forward)
     func gradForward(_ input: Input) ->
-        (value: Output, pullback: (Self.Output.CotangentVector) ->
-            (Self.CotangentVector, Self.Input.CotangentVector)) {
+        (value: Output, pullback: (Self.Output.TangentVector) ->
+            (Self.TangentVector, Self.Input.TangentVector)) {
         switch Context.local.learningPhase {
         case .training:
             return valueWithPullback(at: input) { $0.forwardTraining ($1) }
@@ -93,7 +95,7 @@ public struct FABatchNorm<Scalar: TensorFlowFloatingPoint>: LearningPhaseDepende
 }
 
 struct BatchNormResult<Scalar : TensorFlowFloatingPoint> : Differentiable{
-    let y, batchMean, batchVariance, reserveSpace1, reserveSpace2: Tensor<Scalar>
+    var y, batchMean, batchVariance, reserveSpace1, reserveSpace2: Tensor<Scalar>
 }
 
 public struct TFBatchNorm<Scalar: TensorFlowFloatingPoint>: LearningPhaseDependent, Norm {
@@ -152,9 +154,9 @@ public struct TFBatchNorm<Scalar: TensorFlowFloatingPoint>: LearningPhaseDepende
     static func _vjpFusedBatchNorm(
         _ x : Tensor<Scalar>, scale: Tensor<Scalar>, offset: Tensor<Scalar>, epsilon: Scalar
     ) -> (BatchNormResult<Scalar>, 
-          (BatchNormResult<Scalar>.CotangentVector) -> (Tensor<Scalar>.CotangentVector, 
-                                                        Tensor<Scalar>.CotangentVector, 
-                                                        Tensor<Scalar>.CotangentVector)) {
+          (BatchNormResult<Scalar>.TangentVector) -> (Tensor<Scalar>.TangentVector, 
+                                                        Tensor<Scalar>.TangentVector, 
+                                                        Tensor<Scalar>.TangentVector)) {
       let bnresult = fusedBatchNorm(x, scale: scale, offset: offset, epsilon: epsilon)
   
         return (
@@ -184,7 +186,7 @@ public struct ConvBN<Scalar: TensorFlowFloatingPoint>: FALayer {
 
     @differentiable
     public func forward(_ input: Tensor<Scalar>) -> Tensor<Scalar> {
-        return norm(conv(input))
+        return norm.forward(conv.forward(input))
     }
 }
 
@@ -202,7 +204,8 @@ public struct CnnModelBN: Layer {
     }
     
     @differentiable
-    public func call(_ input: TF) -> TF {
-        return input.compose(convs, pool, linear)
+    public func callAsFunction(_ input: TF) -> TF {
+        // TODO: Work around https://bugs.swift.org/browse/TF-606
+        return linear.forward(pool.forward(convs(input)))
     }
 }

--- a/Sources/Harebrain/07_batchnorm.swift
+++ b/Sources/Harebrain/07_batchnorm.swift
@@ -55,6 +55,10 @@ public protocol Norm: Layer where Input == Tensor<Scalar>, Output == Tensor<Scal
 }
 
 public struct FABatchNorm<Scalar: TensorFlowFloatingPoint>: LearningPhaseDependent, Norm {
+    // TF-603 workaround.
+    public typealias Input = Tensor<Scalar>
+    public typealias Output = Tensor<Scalar>
+
     // Configuration hyperparameters
     @noDerivative var momentum, epsilon: Scalar
     // Running statistics
@@ -173,6 +177,7 @@ public struct TFBatchNorm<Scalar: TensorFlowFloatingPoint>: LearningPhaseDepende
 }
 
 public struct ConvBN<Scalar: TensorFlowFloatingPoint>: FALayer {
+    // TF-603 workaround.
     public typealias Input = Tensor<Scalar>
     public typealias Output = Tensor<Scalar>
     public var conv: FANoBiasConv2D<Scalar>

--- a/Sources/Harebrain/08a_heterogeneous_dictionary.swift
+++ b/Sources/Harebrain/08a_heterogeneous_dictionary.swift
@@ -4,6 +4,8 @@ file to edit: 08a_heterogeneous_dictionary.ipynb
 
 */
 
+
+
 import Path
 
 public protocol HetDictKey {

--- a/Sources/Harebrain/09_optimizer.swift
+++ b/Sources/Harebrain/09_optimizer.swift
@@ -4,10 +4,11 @@ file to edit: 09_optimizer.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
-//Expandable enum to have tab-complete and typo-proof for the hyper-param names
 public struct HyperParams {
     public static let lr = "learningRate"
 }
@@ -43,24 +44,21 @@ extension Dictionary where Value == Int{
     }
 }
 
-//Why doesn't this work?
-//extension Dictionary {
-//    public init(constant: Value, keys: Array(Keys)){
-//        self.init(uniqueKeysWithValues: keys.map { ($0, constant) })
-//    }
-//}
+extension Dictionary {
+    public init(constant: Value, keys: [Key]){
+        self.init(uniqueKeysWithValues: keys.map { ($0, constant) })
+    }
+}
 
 public func initState<Model: Layer>(for model: Model, names: [String]) 
 -> [WritableKeyPath<Model.AllDifferentiableVariables, TF>: [String:TF]] {
     return [WritableKeyPath<Model.AllDifferentiableVariables, TF>: [String:TF]](
-        uniqueKeysWithValues: model.variables.keyPaths.map { ($0, [String:TF](
-            uniqueKeysWithValues: names.map { ($0, TF(0))}
-        ))}
-    )
+        constant: [String: TF](constant: TF(0), keys: names),
+        keys: model.variables.keyPaths)
 }
 
 public class StatefulOptimizer<Model: Layer>
-    where Model.AllDifferentiableVariables == Model.CotangentVector {
+    where Model.AllDifferentiableVariables == Model.TangentVector {
     public typealias ModelKeyPath = WritableKeyPath<Model.AllDifferentiableVariables, TF>
     public typealias SplitDict = [ModelKeyPath: Int]
     public var hpGroups: [[String:Float]]
@@ -86,14 +84,14 @@ public class StatefulOptimizer<Model: Layer>
     }
         
     public func update(
-        _ model: inout Model.AllDifferentiableVariables,
-        along direction: Model.CotangentVector
+        _ variables: inout Model.AllDifferentiableVariables,
+        along direction: Model.TangentVector
     ) {
-        for kp in model.keyPaths {
+        for kp in variables.keyPaths {
             var 𝛁p = direction[keyPath: kp]
             var hps = hpGroups[splitDict[kp]!]
-            stats.forEach() { $0.update(&states[kp]!, p: model[keyPath: kp], 𝛁p: 𝛁p, hps: &hps) }
-            steppers.forEach() { $0.update(&model[keyPath: kp], 𝛁p: &𝛁p, state: states[kp]!, hps: &hps) }
+            stats.forEach() { $0.update(&states[kp]!, p: variables[keyPath: kp], 𝛁p: 𝛁p, hps: &hps) }
+            steppers.forEach() { $0.update(&variables[keyPath: kp], 𝛁p: &𝛁p, state: states[kp]!, hps: &hps) }
             hpGroups[splitDict[kp]!] = hps
         }
     }
@@ -275,7 +273,7 @@ public extension StatefulOptimizer {
 }
 
 extension Learner where Opt.Scalar: BinaryFloatingPoint, 
-    Opt.Model.AllDifferentiableVariables == Opt.Model.CotangentVector{
+    Opt.Model.AllDifferentiableVariables == Opt.Model.TangentVector{
     public class ParamScheduler: Delegate {
         public override var order: Int { return 1 }
         public typealias ScheduleFunc = (Float) -> Float
@@ -314,7 +312,7 @@ public func oneCycleSchedulers(_ lrMax: Float, pctStart:Float=0.25, divStart: Fl
 }
 
 extension Learner where Opt.Scalar: BinaryFloatingPoint, 
-    Opt.Model.AllDifferentiableVariables == Opt.Model.CotangentVector{
+    Opt.Model.AllDifferentiableVariables == Opt.Model.TangentVector{
 
     public func addOneCycleDelegates(_ lrMax: Float, pctStart:Float=0.25, divStart: Float = 10, divEnd: Float = 1e5, 
                                moms: (Float,Float,Float) = (0.95,0.85,0.95)) {

--- a/Sources/Harebrain/11_imagenette.swift
+++ b/Sources/Harebrain/11_imagenette.swift
@@ -22,8 +22,9 @@ public struct ConvLayer: Layer {
     }
     
     @differentiable
-    public func call(_ input: TF) -> TF {
-        return bn(conv(input))
+    public func callAsFunction(_ input: TF) -> TF {
+        // TODO: Work around https://bugs.swift.org/browse/TF-606
+        return bn.forward(conv.forward(input))
     }
 }
 
@@ -36,19 +37,19 @@ public protocol SwitchableLayer: Layer {
 }
 
 public extension SwitchableLayer {
-    func call(_ input: Input) -> Input {
+    func callAsFunction(_ input: Input) -> Input {
         return isOn ? forward(input) : input
     }
 
-    @differentiating(call)
+    @differentiating(callAsFunction)
     func gradForward(_ input: Input) ->
            (value: Input,
-            pullback: (Self.Input.CotangentVector) ->
-                                  (Self.CotangentVector, Self.Input.CotangentVector)) {
+            pullback: (Self.Input.TangentVector) ->
+                                  (Self.TangentVector, Self.Input.TangentVector)) {
         if isOn {
             return valueWithPullback(at: input) { $0.forward($1) } 
         } else {
-            return (input, { (Self.CotangentVector.zero, $0) }) 
+            return (input, { (Self.TangentVector.zero, $0) }) 
         }
     }
 }
@@ -97,7 +98,7 @@ public struct ResBlock: Layer {
     }
     
     @differentiable
-    public func call(_ inp: TF) -> TF {
+    public func callAsFunction(_ inp: TF) -> TF {
         return relu(convs(inp) + idConv(pool(inp)))
     }
     
@@ -125,7 +126,7 @@ public struct XResNet: Layer {
     }
     
     @differentiable
-    public func call(_ inp: TF) -> TF {
+    public func callAsFunction(_ inp: TF) -> TF {
         return inp.compose(stem, maxPool, blocks, pool, linear)
     }
 }


### PR DESCRIPTION
This PR updates the harebrain library to be compatible with the v0.4.0 tool chain.

Note: there are a few open issues in the v0.4.0-rc0 build to be aware of: TF-621 and TF-619.
