### PR TITLE
Specifying macOs 10.13 as build target.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,11 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "Harebrain",
+    platforms: [
+        .macOS(.v10_13),
+    ],
     products: [
         .library(name: "Harebrain", targets: ["Harebrain"]),
     ],


### PR DESCRIPTION
The code base uses APIs available from macOS 10.13 hence
to build the library one has to:

`swift build -Xswiftc -target -Xswiftc x86_64-apple-macosx10.13`

Since swift 5 one can use the `platforms` parameter for `Package.init`
to specify desired target which has to nice advantages:

* one can build the package in macOS w/out passing any flags: `swift build`.
* The generated Xcode project has the right Deployment Target setting for the Targets.

In order to take advantage of this functionality `swift-tools-version`
needs to bumped. Which is ok since S4TF toolchain is needed to build this pkg.